### PR TITLE
Fix the formatting issue of response 

### DIFF
--- a/src/main/java/seedu/address/logic/parser/MarkCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/MarkCommandParser.java
@@ -4,6 +4,7 @@ import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.MarkCommand;
+import seedu.address.logic.parser.exceptions.InvalidFormatException;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -22,8 +23,10 @@ public class MarkCommandParser implements Parser<MarkCommand> {
             Index index = ParserUtil.parseIndex(args);
             return new MarkCommand(index);
         } catch (ParseException pe) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, MarkCommand.MESSAGE_USAGE), pe);
+            throw new InvalidFormatException(
+                    MESSAGE_INVALID_COMMAND_FORMAT,
+                    MarkCommand.COMMAND_WORD,
+                    MarkCommand.MESSAGE_USAGE);
         }
     }
 

--- a/src/main/java/seedu/address/logic/parser/UnmarkCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/UnmarkCommandParser.java
@@ -4,6 +4,7 @@ import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.UnmarkCommand;
+import seedu.address.logic.parser.exceptions.InvalidFormatException;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -22,8 +23,11 @@ public class UnmarkCommandParser implements Parser<UnmarkCommand> {
             Index index = ParserUtil.parseIndex(args);
             return new UnmarkCommand(index);
         } catch (ParseException pe) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnmarkCommand.MESSAGE_USAGE), pe);
+            throw new InvalidFormatException(
+                    MESSAGE_INVALID_COMMAND_FORMAT,
+                    UnmarkCommand.COMMAND_WORD,
+                    UnmarkCommand.MESSAGE_USAGE
+            );
         }
     }
 

--- a/src/test/java/seedu/address/logic/parser/MarkCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/MarkCommandParserTest.java
@@ -18,8 +18,10 @@ public class MarkCommandParserTest {
     }
 
     @Test
-    public void parse_invalidArgs_throwsParseException() {
-        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                MarkCommand.MESSAGE_USAGE));
+    public void parse_invalidArgs_throwsInvalidFormatException() {
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                MarkCommand.COMMAND_WORD) + "\nUsage: " + MarkCommand.MESSAGE_USAGE;
+
+        assertParseFailure(parser, "a", expectedMessage);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/UnmarkCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/UnmarkCommandParserTest.java
@@ -19,7 +19,9 @@ public class UnmarkCommandParserTest {
 
     @Test
     public void parse_invalidArgs_throwsParseException() {
-        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                UnmarkCommand.MESSAGE_USAGE));
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                UnmarkCommand.COMMAND_WORD) + "\nUsage: " + UnmarkCommand.MESSAGE_USAGE;
+
+        assertParseFailure(parser, "a", expectedMessage);
     }
 }


### PR DESCRIPTION
The formatting of the system response to wrong usage of mark and unmark commands has been fixed to be the same as the wrong usage of add, delete and edit commands.

This has been done by replacing ParseException with InvalidFormatException in MarkCommandParser and UnmarkCommandParser