### PR TITLE
Add Note to Edit Command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DEADLINE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_MEMBER;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PRIORITY;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_TASKS;
 
@@ -43,6 +44,7 @@ public class EditCommand extends Command {
             + "Existing values will be overwritten by the input values.\n"
             + "Parameters: INDEX (must be a positive integer) "
             + "[" + PREFIX_DESCRIPTION + "DESCRIPTION] "
+            + "[" + PREFIX_NOTE + "NOTE] "
             + "[" + PREFIX_DEADLINE + "DEADLINE]"
             + "[" + PREFIX_PRIORITY + "PRIORITY]..."
             + "[" + PREFIX_MEMBER + "TAG]...\n"
@@ -98,13 +100,13 @@ public class EditCommand extends Command {
         assert taskToEdit != null;
 
         Description updatedDescription = editTaskDescriptor.getDescription().orElse(taskToEdit.getDescription());
+        Note updatedNote = editTaskDescriptor.getNote().orElse(taskToEdit.getNote());
         Deadline updatedDeadline = editTaskDescriptor.getDeadline().orElse(taskToEdit.getDeadline());
         Priority updatedPriority = editTaskDescriptor.getPriority().orElse(taskToEdit.getPriority());
         Set<Member> updatedMembers = editTaskDescriptor.getMembers().orElse(taskToEdit.getMembers());
         Status status = taskToEdit.getStatus(); //Not edited using editCommand
-        Note note = taskToEdit.getNote(); //Not edited using editCommand
 
-        return new Task(updatedDescription, status, note, updatedDeadline, updatedPriority, updatedMembers);
+        return new Task(updatedDescription, status, updatedNote, updatedDeadline, updatedPriority, updatedMembers);
     }
 
     @Override
@@ -137,6 +139,7 @@ public class EditCommand extends Command {
      */
     public static class EditTaskDescriptor {
         private Description description;
+        private Note note;
         private Deadline deadline;
         private Priority priority;
         private Set<Tag> tags;
@@ -151,6 +154,7 @@ public class EditCommand extends Command {
          */
         public EditTaskDescriptor(EditTaskDescriptor toCopy) {
             setDescription(toCopy.description);
+            setNote(toCopy.note);
             setTags(toCopy.tags);
             setDeadline(toCopy.deadline);
             setPriority(toCopy.priority);
@@ -161,7 +165,15 @@ public class EditCommand extends Command {
          * Returns true if at least one field is edited.
          */
         public boolean isAnyFieldEdited() {
-            return CollectionUtil.isAnyNonNull(description, tags, deadline, priority, members);
+            return CollectionUtil.isAnyNonNull(description, note, tags, deadline, priority, members);
+        }
+
+        public void setNote (Note note) {
+            this.note = note;
+        }
+
+        public Optional<Note> getNote() {
+            return Optional.ofNullable(note);
         }
 
         public void setDeadline(Deadline deadline) {
@@ -234,6 +246,7 @@ public class EditCommand extends Command {
 
             EditTaskDescriptor otherEditTaskDescriptor = (EditTaskDescriptor) other;
             return Objects.equals(description, otherEditTaskDescriptor.description)
+                    && Objects.equals(note, otherEditTaskDescriptor.note)
                     && Objects.equals(tags, otherEditTaskDescriptor.tags)
                     && Objects.equals(deadline, otherEditTaskDescriptor.deadline)
                     && Objects.equals(priority, otherEditTaskDescriptor.priority)
@@ -244,6 +257,7 @@ public class EditCommand extends Command {
         public String toString() {
             return new ToStringBuilder(this)
                     .add("description", description)
+                    .add("note", note)
                     .add("tags", tags)
                     .add("deadline", deadline)
                     .add("priority", priority)

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -168,7 +168,7 @@ public class EditCommand extends Command {
             return CollectionUtil.isAnyNonNull(description, note, tags, deadline, priority, members);
         }
 
-        public void setNote (Note note) {
+        public void setNote(Note note) {
             this.note = note;
         }
 

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -5,6 +5,7 @@ import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DEADLINE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_MEMBER;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PRIORITY;
 
 import java.util.Collection;
@@ -35,7 +36,7 @@ public class EditCommandParser implements Parser<EditCommand> {
     public EditCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_DESCRIPTION, PREFIX_MEMBER, PREFIX_DEADLINE, PREFIX_PRIORITY);
+                ArgumentTokenizer.tokenize(args, PREFIX_DESCRIPTION, PREFIX_NOTE, PREFIX_MEMBER, PREFIX_DEADLINE, PREFIX_PRIORITY);
 
         // check if the preamble is empty, if it is, then it must be malformed
         if (argMultimap.getPreamble().isEmpty()) {
@@ -51,7 +52,11 @@ public class EditCommandParser implements Parser<EditCommand> {
             editTaskDescriptor.setDescription(ParserUtil.parseDescription(argMultimap
                     .getValue(PREFIX_DESCRIPTION).get()));
         }
-        // TODO: Add tests for deadline, members and priority in EditCommandParserTest
+        if (argMultimap.getValue(PREFIX_NOTE).isPresent()) {
+            editTaskDescriptor.setNote(ParserUtil.parseNote(argMultimap
+                    .getValue(PREFIX_NOTE).get()));
+        }
+        // TODO: Add tests for deadline, note, members and priority in EditCommandParserTest
         if (argMultimap.getValue(PREFIX_DEADLINE).isPresent()) {
             editTaskDescriptor.setDeadline(ParserUtil.parseDeadline(argMultimap
                     .getValue(PREFIX_DEADLINE).get()));
@@ -64,6 +69,7 @@ public class EditCommandParser implements Parser<EditCommand> {
         // now validate the index
         Index index = ParserUtil.parseIndex(argMultimap.getPreamble());
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_DESCRIPTION);
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NOTE);
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_DEADLINE);
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_PRIORITY);
 

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -36,7 +36,8 @@ public class EditCommandParser implements Parser<EditCommand> {
     public EditCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_DESCRIPTION, PREFIX_NOTE, PREFIX_MEMBER, PREFIX_DEADLINE, PREFIX_PRIORITY);
+                ArgumentTokenizer.tokenize(args, PREFIX_DESCRIPTION, PREFIX_NOTE,
+                        PREFIX_MEMBER, PREFIX_DEADLINE, PREFIX_PRIORITY);
 
         // check if the preamble is empty, if it is, then it must be malformed
         if (argMultimap.getPreamble().isEmpty()) {

--- a/src/test/java/seedu/address/logic/commands/EditTaskDescriptorTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditTaskDescriptorTest.java
@@ -46,7 +46,8 @@ public class EditTaskDescriptorTest {
     public void toStringMethod() {
         EditTaskDescriptor editTaskDescriptor = new EditTaskDescriptor();
         String expected = EditTaskDescriptor.class.getCanonicalName() + "{description="
-                + editTaskDescriptor.getDescription().orElse(null) + ", tags="
+                + editTaskDescriptor.getDescription().orElse(null) + ", note="
+                + editTaskDescriptor.getNote().orElse(null) + ", tags="
                 + editTaskDescriptor.getTags().orElse(null) + ", deadline="
                 + editTaskDescriptor.getDeadline().orElse(null) + ", priority="
                 + editTaskDescriptor.getPriority().orElse(null) + ", members="


### PR DESCRIPTION
## Background
Currently, we can only add note through the note command:
```
note [INDEX] n/[NOTE]
```
We want to allow users to be able to edit the note through the edit command as well
```
edit [INDEX] n/[NOTE]
```

## Information
Note that this PR is still **Work In Progress**. However, feel free to look through it and make comments if you have any!