### PR TITLE
Allow Edit Command for Priority to None

### DIFF
--- a/src/main/java/seedu/address/model/task/Priority.java
+++ b/src/main/java/seedu/address/model/task/Priority.java
@@ -48,7 +48,7 @@ public enum Priority {
         case "low":
         case "medium":
         case "high":
-        case "none":    
+        case "none":
             return true;
         default:
             return false;

--- a/src/main/java/seedu/address/model/task/Priority.java
+++ b/src/main/java/seedu/address/model/task/Priority.java
@@ -31,6 +31,8 @@ public enum Priority {
             return Priority.MEDIUM;
         case "high":
             return Priority.HIGH;
+        case "none":
+            return Priority.NONE;
         default:
             throw new IllegalArgumentException("Invalid Priority Value: ");
         }
@@ -46,6 +48,7 @@ public enum Priority {
         case "low":
         case "medium":
         case "high":
+        case "none":    
             return true;
         default:
             return false;


### PR DESCRIPTION
Previously, we cannot edit priority levels back to `none`, after assigning them a  `low`/`medium`/`high`. 

Now, we can edit tasks' priority levels from `none`/`low`/`medium`/`high` back to `none`.