### PR TITLE
Update Sort Parameter Parsers

### DIFF
--- a/src/main/java/seedu/address/logic/sort/enums/SortOrderEnum.java
+++ b/src/main/java/seedu/address/logic/sort/enums/SortOrderEnum.java
@@ -22,7 +22,9 @@ public enum SortOrderEnum {
      * @throws IllegalArgumentException if the input String is not a valid input String value
      */
     public static SortOrderEnum of(String sortOrder) {
-        switch (sortOrder) {
+        String strippedSortOrder = sortOrder.strip();
+
+        switch (strippedSortOrder) {
         case "a":
         case "asc":
         case "ascending":

--- a/src/main/java/seedu/address/logic/sort/enums/SortTypeEnum.java
+++ b/src/main/java/seedu/address/logic/sort/enums/SortTypeEnum.java
@@ -25,7 +25,9 @@ public enum SortTypeEnum {
      * @throws IllegalArgumentException if the input String is not a valid input String value
      */
     public static SortTypeEnum of(String sortType) {
-        switch (sortType) {
+        String strippedSortType = sortType.strip();
+
+        switch (strippedSortType) {
         case "t":
         case "tn":
         case "task":


### PR DESCRIPTION
Update the sort command parameter parsers to ensure that leading and trailing whitespace are stripped before parsing the text into the different enums.