### PR TITLE
Amend types of member names that are valid

### DIFF
--- a/src/main/java/seedu/address/model/tag/Member.java
+++ b/src/main/java/seedu/address/model/tag/Member.java
@@ -9,7 +9,8 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class Member {
 
-    public static final String MESSAGE_CONSTRAINTS = "Member names should be non-empty.";
+    public static final String MESSAGE_CONSTRAINTS = "Member names should not be blank or contain /";
+    public static final String VALIDATION_REGEX = "^(?!\\s*$)[^/]*$";
 
     public final String memberName;
 
@@ -29,7 +30,7 @@ public class Member {
      * Returns true if a given string is a valid member name.
      */
     public static boolean isValidName(String test) {
-        return !(test.isEmpty());
+        return test.matches(VALIDATION_REGEX);
     }
 
     @Override

--- a/src/test/java/seedu/address/model/tag/MemberTest.java
+++ b/src/test/java/seedu/address/model/tag/MemberTest.java
@@ -16,14 +16,29 @@ class MemberTest {
 
     @Test
     public void constructor_invalidMemberName_throwsIllegalArgumentException() {
-        String invalidMemberName = "";
+        final String invalidMemberName = "";
         assertThrows(IllegalArgumentException.class, () -> new Member(invalidMemberName));
+
+        final String invalidMemberNameTwo = "    ";
+        assertThrows(IllegalArgumentException.class, () -> new Member(invalidMemberNameTwo));
+
+        final String invalidMemberNameThree = "mary/";
+        assertThrows(IllegalArgumentException.class, () -> new Member(invalidMemberNameThree));
     }
 
     @Test
-    public void isValidMemberName() {
+    public void isValidName_null_throwsNullPointerException() {
         // null tag name
         assertThrows(NullPointerException.class, () -> Member.isValidName(null));
+    }
+
+    @Test
+    public void isValidName_invalidMemberName_false() {
+        final String invalidMemberNameTwo = "    ";
+        assertFalse(Member.isValidName(invalidMemberNameTwo));
+
+        final String invalidMemberNameThree = "mary/";
+        assertFalse(Member.isValidName(invalidMemberNameThree));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/tag/MemberTest.java
+++ b/src/test/java/seedu/address/model/tag/MemberTest.java
@@ -15,13 +15,19 @@ class MemberTest {
     }
 
     @Test
-    public void constructor_invalidMemberName_throwsIllegalArgumentException() {
+    public void constructor_emptyName_throwsIllegalArgumentException() {
         final String invalidMemberName = "";
         assertThrows(IllegalArgumentException.class, () -> new Member(invalidMemberName));
+    }
 
+    @Test
+    public void constructor_whitespaceName_throwsIllegalArgumentException() {
         final String invalidMemberNameTwo = "    ";
         assertThrows(IllegalArgumentException.class, () -> new Member(invalidMemberNameTwo));
+    }
 
+    @Test
+    public void constructor_nameWithSlash_throwsIllegalArgumentException() {
         final String invalidMemberNameThree = "mary/";
         assertThrows(IllegalArgumentException.class, () -> new Member(invalidMemberNameThree));
     }
@@ -33,10 +39,13 @@ class MemberTest {
     }
 
     @Test
-    public void isValidName_invalidMemberName_false() {
+    public void isValidName_whitespaceName_false() {
         final String invalidMemberNameTwo = "    ";
         assertFalse(Member.isValidName(invalidMemberNameTwo));
+    }
 
+    @Test
+    public void isValidName_nameWithSlash_false() {
         final String invalidMemberNameThree = "mary/";
         assertFalse(Member.isValidName(invalidMemberNameThree));
     }


### PR DESCRIPTION
Member names are now unable to be just whitespace characters and are not allowed to contain any forward slashes ("/")

Closes #136 