### PR TITLE
Fix TaskCard Selection Bug and ESCAPE Clearing Side Panel Bug

### DIFF
--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -22,6 +22,7 @@ public class ModelManager implements Model {
 
     private final TaskWise taskWise;
     private final UserPrefs userPrefs;
+
     private final FilteredList<Task> filteredTasks;
     private MainWindow mainWindow;
 

--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -33,11 +33,11 @@ public class CommandBox extends UiPart<Region> {
         commandTextField.textProperty().addListener((unused1, unused2, unused3) -> setStyleToDefault());
         commandTextField.addEventFilter(KeyEvent.KEY_PRESSED, event -> {
             switch (event.getCode()) {
-                case ESCAPE:
-                    taskListPanel.clearSidePanel();
-                    break;
-                default:
-                    break;
+            case ESCAPE:
+                taskListPanel.clearSidePanel();
+                break;
+            default:
+                break;
             }
         });
     }

--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -3,6 +3,7 @@ package seedu.address.ui;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.control.TextField;
+import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.Region;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -25,11 +26,20 @@ public class CommandBox extends UiPart<Region> {
     /**
      * Creates a {@code CommandBox} with the given {@code CommandExecutor}.
      */
-    public CommandBox(CommandExecutor commandExecutor) {
+    public CommandBox(CommandExecutor commandExecutor, TaskListPanel taskListPanel) {
         super(FXML);
         this.commandExecutor = commandExecutor;
         // calls #setStyleToDefault() whenever there is a change to the text of the command box.
         commandTextField.textProperty().addListener((unused1, unused2, unused3) -> setStyleToDefault());
+        commandTextField.addEventFilter(KeyEvent.KEY_PRESSED, event -> {
+            switch (event.getCode()) {
+                case ESCAPE:
+                    taskListPanel.clearSidePanel();
+                    break;
+                default:
+                    break;
+            }
+        });
     }
 
     /**

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -75,7 +75,7 @@ public class MainWindow extends UiPart<Stage> {
     }
 
     public void setTaskToTaskListPanel(Task task) {
-        taskListPanel.setTaskInformation(task);
+        taskListPanel.selectAndSetTaskInformation(task);
     }
 
     private void setAccelerators() {
@@ -125,7 +125,7 @@ public class MainWindow extends UiPart<Stage> {
         StatusBarFooter statusBarFooter = new StatusBarFooter(logic.getTaskWiseFilePath());
         statusbarPlaceholder.getChildren().add(statusBarFooter.getRoot());
 
-        CommandBox commandBox = new CommandBox(this::executeCommand);
+        CommandBox commandBox = new CommandBox(this::executeCommand, taskListPanel);
         commandBoxPlaceholder.getChildren().add(commandBox.getRoot());
     }
 

--- a/src/main/java/seedu/address/ui/TaskListPanel.java
+++ b/src/main/java/seedu/address/ui/TaskListPanel.java
@@ -101,6 +101,9 @@ public class TaskListPanel extends UiPart<Region> {
         this.destroyTaskInformationView();
     }
 
+    /**
+     * Clears the side panel.
+     */
     public void clearSidePanel() {
         this.taskListView.getSelectionModel().clearSelection();
         this.destroyTaskInformationView();
@@ -141,9 +144,11 @@ public class TaskListPanel extends UiPart<Region> {
         this.getNoteField(task);
 
         this.taskInfoView.setFitToHeight(false);
-
     }
 
+    /**
+     * Selects the task in the list view and sets the task information.
+     */
     public void selectAndSetTaskInformation(Task task) {
         this.taskListView.getSelectionModel().select(task);
         this.setTaskInformation(task);

--- a/src/main/java/seedu/address/ui/TaskListPanel.java
+++ b/src/main/java/seedu/address/ui/TaskListPanel.java
@@ -90,8 +90,7 @@ public class TaskListPanel extends UiPart<Region> {
         taskListView.setOnKeyPressed(
                 x -> {
                     if (x.getCode() == KeyCode.ESCAPE) {
-                        taskListView.getSelectionModel().clearSelection();
-                        this.destroyTaskInformationView();
+                        clearSidePanel();
                     }
 
                     x.consume();
@@ -99,6 +98,11 @@ public class TaskListPanel extends UiPart<Region> {
         );
         //@@author
 
+        this.destroyTaskInformationView();
+    }
+
+    public void clearSidePanel() {
+        this.taskListView.getSelectionModel().clearSelection();
         this.destroyTaskInformationView();
     }
 
@@ -137,6 +141,12 @@ public class TaskListPanel extends UiPart<Region> {
         this.getNoteField(task);
 
         this.taskInfoView.setFitToHeight(false);
+
+    }
+
+    public void selectAndSetTaskInformation(Task task) {
+        this.taskListView.getSelectionModel().select(task);
+        this.setTaskInformation(task);
     }
 
     private void destroyTaskInformationView() {

--- a/src/main/resources/view/CommandBox.fxml
+++ b/src/main/resources/view/CommandBox.fxml
@@ -2,7 +2,6 @@
 
 <?import javafx.scene.control.TextField?>
 <?import javafx.scene.layout.StackPane?>
-
 <StackPane styleClass="stack-pane" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
   <TextField fx:id="commandTextField" onAction="#handleCommandEntered" promptText="Enter command here..."/>
 </StackPane>


### PR DESCRIPTION
## Background
Before this, when we click on the task using the GUI, the task will be highlighted in brown. However, when you view a task using the CLI, the task viewed is not highlighted in brown. This PR fixes that. 

Secondly, before this, when you view a task by clicking on the task using the GUI, and you press the ESCAPE key, the information in the side panel would clear, but when you view a task using the CLI and press the ESCAPE key, nothing happens. This PR fixes that as well.