### PR TITLE
Change All Occurrences of "Task Name" to "Task Description"

### DIFF
--- a/src/main/java/seedu/address/logic/commands/SortCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SortCommand.java
@@ -62,7 +62,7 @@ public class SortCommand extends Command {
         ObservableList<Task> taskList = model.getTaskWise().getTaskList();
 
         switch (sortTypeEnum) {
-        case TASK_NAME:
+        case TASK_DESCRIPTION:
             model.setAllTasks(taskList.sorted(SortUtil.ofTaskName(this.sortOrderEnum)));
             break;
         case PRIORITY:

--- a/src/main/java/seedu/address/logic/sort/SortUtil.java
+++ b/src/main/java/seedu/address/logic/sort/SortUtil.java
@@ -70,7 +70,7 @@ public abstract class SortUtil {
      * Returns a {@code Comparator<Task>}, which compares two Tasks and returns an integer
      * indicating if the first object is less than, equal to or larger than the second object.
      * <p>
-     * This function is used to generate the comparator function for sorting by Task Name.
+     * This function is used to generate the comparator function for sorting by Task Description.
      * </p>
      *
      * @param sortOrderEnum The order to sort the task by, represented by a {@code SortOrderEnum}

--- a/src/main/java/seedu/address/logic/sort/enums/SortTypeEnum.java
+++ b/src/main/java/seedu/address/logic/sort/enums/SortTypeEnum.java
@@ -4,7 +4,7 @@ package seedu.address.logic.sort.enums;
  * Enum to represent the field to sort by in the sort.
  */
 public enum SortTypeEnum {
-    TASK_NAME("task name"),
+    TASK_DESCRIPTION("task description"),
     STATUS("status"),
     PRIORITY("priority"),
     DEADLINE("deadline");
@@ -29,11 +29,11 @@ public enum SortTypeEnum {
 
         switch (strippedSortType) {
         case "t":
-        case "tn":
+        case "td":
         case "task":
-        case "tsk nm":
-        case "task name":
-            return SortTypeEnum.TASK_NAME;
+        case "tsk dsc":
+        case "task description":
+            return SortTypeEnum.TASK_DESCRIPTION;
         case "p":
         case "pr":
         case "pri":

--- a/src/test/java/seedu/address/logic/commands/SortCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SortCommandTest.java
@@ -49,9 +49,9 @@ public class SortCommandTest {
     private static final Priority SECOND_PRIORITY = Priority.LOW;
     private static final Set<Member> DEFAULT_MEMBERS = new HashSet<>(List.of(new Member("John")));
     private static final SortCommand validTaskNameAsc = new SortCommand(SortOrderEnum.ASCENDING,
-            SortTypeEnum.TASK_NAME);
+            SortTypeEnum.TASK_DESCRIPTION);
     private static final SortCommand validTaskNameDes = new SortCommand(SortOrderEnum.DESCENDING,
-            SortTypeEnum.TASK_NAME);
+            SortTypeEnum.TASK_DESCRIPTION);
     private static final SortCommand validPriorityAsc = new SortCommand(SortOrderEnum.ASCENDING,
             SortTypeEnum.PRIORITY);
     private static final SortCommand validPriorityDes = new SortCommand(SortOrderEnum.DESCENDING,
@@ -166,7 +166,7 @@ public class SortCommandTest {
         assertTrue(validTaskNameAsc.equals(validTaskNameAsc));
 
         // same values -> returns true
-        assertTrue(validTaskNameAsc.equals(new SortCommand(SortOrderEnum.ASCENDING, SortTypeEnum.TASK_NAME)));
+        assertTrue(validTaskNameAsc.equals(new SortCommand(SortOrderEnum.ASCENDING, SortTypeEnum.TASK_DESCRIPTION)));
 
         // different types -> returns false
         assertFalse(validTaskNameAsc.equals(true));

--- a/src/test/java/seedu/address/logic/sort/enums/SortTypeEnumTest.java
+++ b/src/test/java/seedu/address/logic/sort/enums/SortTypeEnumTest.java
@@ -8,11 +8,11 @@ import org.junit.jupiter.api.Test;
 public class SortTypeEnumTest {
     @Test
     public void of_validTaskName_success() {
-        assertEquals(SortTypeEnum.of("t"), SortTypeEnum.TASK_NAME);
-        assertEquals(SortTypeEnum.of("tn"), SortTypeEnum.TASK_NAME);
-        assertEquals(SortTypeEnum.of("task"), SortTypeEnum.TASK_NAME);
-        assertEquals(SortTypeEnum.of("tsk nm"), SortTypeEnum.TASK_NAME);
-        assertEquals(SortTypeEnum.of("task name"), SortTypeEnum.TASK_NAME);
+        assertEquals(SortTypeEnum.of("t"), SortTypeEnum.TASK_DESCRIPTION);
+        assertEquals(SortTypeEnum.of("td"), SortTypeEnum.TASK_DESCRIPTION);
+        assertEquals(SortTypeEnum.of("task"), SortTypeEnum.TASK_DESCRIPTION);
+        assertEquals(SortTypeEnum.of("tsk dsc"), SortTypeEnum.TASK_DESCRIPTION);
+        assertEquals(SortTypeEnum.of("task description"), SortTypeEnum.TASK_DESCRIPTION);
     }
 
     @Test
@@ -34,7 +34,7 @@ public class SortTypeEnumTest {
 
     @Test
     public void of_invalidTaskName_failure() {
-        assertThrows(IllegalArgumentException.class, () -> SortTypeEnum.of("taskname"));
+        assertThrows(IllegalArgumentException.class, () -> SortTypeEnum.of("taskdescription"));
     }
 
     @Test
@@ -49,7 +49,7 @@ public class SortTypeEnumTest {
 
     @Test
     public void toString_taskName_success() {
-        assertEquals(SortTypeEnum.TASK_NAME.toString(), "task name");
+        assertEquals(SortTypeEnum.TASK_DESCRIPTION.toString(), "task description");
     }
 
     @Test


### PR DESCRIPTION
This PR fixes the oversight on the naming of the task description, by changing all references to "name" to "description".