### PR TITLE
Update priority prefix duplicate check and clear command message

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearCommand.java
@@ -11,7 +11,7 @@ import seedu.address.model.TaskWise;
 public class ClearCommand extends Command {
 
     public static final String COMMAND_WORD = "clear";
-    public static final String MESSAGE_SUCCESS = "Address book has been cleared!";
+    public static final String MESSAGE_SUCCESS = "TaskWise has been cleared!";
 
 
     @Override

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -43,7 +43,7 @@ public class AddCommandParser implements Parser<AddCommand> {
                     AddCommand.MESSAGE_USAGE);
         }
 
-        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_DESCRIPTION, PREFIX_DEADLINE);
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_DESCRIPTION, PREFIX_DEADLINE, PREFIX_PRIORITY);
         Description description = ParserUtil.parseDescription(argMultimap.getValue(PREFIX_DESCRIPTION).get());
 
         AddCommand.AddTaskDescriptor addTaskDescriptor = new AddCommand.AddTaskDescriptor();


### PR DESCRIPTION
According to our PE-D bugs that we have accepted, I fixed the following 2 bugs assigned to me:
* `AddCommandParser` should check for duplicate prefix for `p/` (priority) and throw an error message if said priority prefix has more than 1.
* Clear command message has been changed from "Address book has been cleared!" to "TaskWise has been cleared!".